### PR TITLE
Remove dependency with package 'config'. Use lazy connection during schema declarations.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,6 @@ orientdb: {
 }
 ```
 > **IMPORTANT**
-> Rieluz configuration must have the key "orientdb".
 > Every connection configuration is similar to the [OrientJS](https://github.com/orientechnologies/orientjs) configuration schema.
 
 Can be specify as many connection as needed. Every connection is identify by its name.

--- a/lib/index.js
+++ b/lib/index.js
@@ -74,7 +74,7 @@ export var connect = function(config, done) {
   for (let key in config.connections) {
     if (config.connections.hasOwnProperty(key)) {
       boot_connections.push((cb) => {
-        let gm = GraphManager.getInstance(key);
+        let gm = GraphManager.getInstance(key, config);
         gm.createDatabaseIfNotExist(cb)
       });
     }
@@ -89,7 +89,7 @@ export var connect = function(config, done) {
       let item = models[key];
 
       tasks.push((cb) => {
-        let gm = GraphManager.getInstance(item.connection);
+        let gm = GraphManager.getInstance(item.connection, config);
         gm.createClassIfNotExist(item.className, item.superClass, (err) => {
           gm.syncClassProperties(item.className, item.schema, cb)
         });

--- a/lib/models/GraphManager.js
+++ b/lib/models/GraphManager.js
@@ -2,7 +2,6 @@
 
 import OrientDB from 'orientjs';
 import _ from 'lodash';
-import config from 'config';
 import async from 'async';
 import GraphConfigurationSchema  from './../config/configSchema';
 import GraphError from './../exception';
@@ -11,9 +10,7 @@ let instances = {};
 
 
 class GraphManager {
-  constructor(connection) {
-
-    let configuration = config.get('orientdb');
+  constructor(connection, configuration) {
 
     let validator = GraphConfigurationSchema.validate(configuration);
 
@@ -133,9 +130,9 @@ class GraphManager {
     });
   }
 
-  static getInstance(connection){
+  static getInstance(connection, configuration){
     if (connection !== undefined && instances[connection] === undefined) {
-      instances[connection] = new GraphManager(connection);
+      instances[connection] = new GraphManager(connection, configuration);
     }
 
     //noinspection JSAnnotator
@@ -143,7 +140,7 @@ class GraphManager {
   }
 }
 
-export const getInstance = function(connection) {
-  return GraphManager.getInstance(connection)
+export const getInstance = function(connection, configuration) {
+  return GraphManager.getInstance(connection, configuration)
 };
 

--- a/lib/models/GraphManager.js
+++ b/lib/models/GraphManager.js
@@ -59,7 +59,7 @@ class GraphManager {
       this.database.class.list().then((classes) => {
         let className = undefined;
         if (_.isEmpty(classes) == false) {
-          className = _.find(classes, (cls) => cls.name == name )
+          className = _.find(classes, (cls) => _.toLower(cls.name) == _.toLower(name) )
         }
 
         if (className === undefined) {
@@ -92,7 +92,7 @@ class GraphManager {
         let schemaProperties = _.keys(schema.structure);
 
         let classProperties = _.isEmpty(properties) ? schemaProperties : _.reject(schemaProperties, (prop) => {
-          return undefined !== _.find(properties, (p) => p.name == prop);
+          return undefined !== _.find(properties, (p) => _.toLower(p.name) == _.toLower(prop));
         });
 
         // Save the properties

--- a/lib/models/Vertex.js
+++ b/lib/models/Vertex.js
@@ -38,7 +38,7 @@ class Vertex {
    */
   save (done) {
     if(this.isValid(this.data)) {
-      Vertex.collection.gm.database.insert().into(this.className).set(this.data).one()
+      Vertex.collection.gm().database.insert().into(this.className).set(this.data).one()
           .then((record) => done(null, Vertex.collection.inflate(record)));
     } else {
       // Return errors if schema is not valid
@@ -51,7 +51,7 @@ class Vertex {
    * @param done
    */
   delete(done) {
-    Vertex.collection.gm.record.delete(this.rid).then(done);
+    Vertex.collection.gm().record.delete(this.rid).then(done);
   }
 
   /**

--- a/lib/models/VertexCollection.js
+++ b/lib/models/VertexCollection.js
@@ -6,10 +6,24 @@ import * as GraphManager from './GraphManager';
 class VertexCollection {
   constructor (className, schema, connection) {
     this.conn = connection;
-    this.gm = GraphManager.getInstance(this.conn);
+    this._gm = null;
 
     this.className = className;
     this.schema = schema;
+  }
+
+  /**
+   * Get Graph Manager connected instance.
+   * @returns GraphManager
+   */
+  gm() {
+    if (this._gm) {
+      return this._gm;
+    }
+
+    this._gm = GraphManager.getInstance(this.conn);
+
+    return this._gm;
   }
 
   /**
@@ -21,7 +35,7 @@ class VertexCollection {
   upsert(criteria, data, done) {
     // Validate data before the upset
     if(this.schema.validate(data)) {
-      this.gm.database.update(this.className).set(data).upsert(criteria).return('after @this').one()
+      this.gm().database.update(this.className).set(data).upsert(criteria).return('after @this').one()
         .then((record) => { done(null, this.inflate(record)); });
     } else {
       // Return errors if schema is not valid
@@ -57,7 +71,7 @@ class VertexCollection {
   create(data, done) {
     // Validate data
     if(this.schema.validate(data)) {
-      this.gm.database.insert().into(this.className).set(data).one()
+      this.gm().database.insert().into(this.className).set(data).one()
           .then((record) => done(null, this.inflate(record)));
     } else {
       // Return errors if schema is not valid
@@ -71,7 +85,7 @@ class VertexCollection {
    * @param done
    */
   delete(criteria, done) {
-    this.gm.database.delete('VERTEX').from(this.className).where(criteria).one().then((count) => done(null, count));
+    this.gm().database.delete('VERTEX').from(this.className).where(criteria).one().then((count) => done(null, count));
   }
 
   /**
@@ -80,7 +94,7 @@ class VertexCollection {
    * @param done
    */
   findOne(criteria, done) {
-    this.gm.database.select().from(this.className).where(criteria).one().then((record) => done(null, this.inflate(record)))
+    this.gm().database.select().from(this.className).where(criteria).one().then((record) => done(null, this.inflate(record)))
   }
 
   /**
@@ -93,11 +107,11 @@ class VertexCollection {
    * @param done
    */
   upsertEdge(label, from, to, data, done) {
-    this.gm.database.select().from('E').where({in: to, out: from}).one().then((edge) => {
+    this.gm().database.select().from('E').where({in: to, out: from}).one().then((edge) => {
       if (edge === undefined) {
         this.createEdge(label, from, to, data, done)
       } else {
-        this.gm.database.update(edge['@rid'].toString()).set(data).one().then((edge) => done(null, edge));
+        this.gm().database.update(edge['@rid'].toString()).set(data).one().then((edge) => done(null, edge));
       }
     });
   }
@@ -112,7 +126,7 @@ class VertexCollection {
    * @param done
    */
   createEdge(label, from, to, data, done) {
-    this.gm.database.create('EDGE', label).set(data).from(from).to(to).one().then((edge) => done(null, edge));
+    this.gm().database.create('EDGE', label).set(data).from(from).to(to).one().then((edge) => done(null, edge));
   }
 
   /**
@@ -125,7 +139,7 @@ class VertexCollection {
    * @param done
    */
   deleteEdge(_class=null, from, to, done) {
-    this.gm.database.delete('EDGE', _class).from(from).to(to).scalar().then((count) => done(null, count));
+    this.gm().database.delete('EDGE', _class).from(from).to(to).scalar().then((count) => done(null, count));
   }
 
   /**
@@ -136,13 +150,13 @@ class VertexCollection {
    * @param done
    */
   query(query, params, done) {
-    this.gm.database.query(query, {params: params}).then((results) => {
+    this.gm().database.query(query, {params: params}).then((results) => {
       done(null, results);
     }, done);
   }
 
   getQueryBuilder() {
-    return this.gm.database;
+    return this.gm().database;
   }
 }
 

--- a/lib/models/VertexCollection.js
+++ b/lib/models/VertexCollection.js
@@ -17,11 +17,9 @@ class VertexCollection {
    * @returns GraphManager
    */
   gm() {
-    if (this._gm) {
-      return this._gm;
+    if (!this._gm) {
+      this._gm = GraphManager.getInstance(this.conn);
     }
-
-    this._gm = GraphManager.getInstance(this.conn);
 
     return this._gm;
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rieluz",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "description": "Just another OGM for OrientDB",
   "keywords": [
     "orientdb",
@@ -27,7 +27,6 @@
   },
   "dependencies": {
     "async": "^2.0.0-rc.3",
-    "config": "^1.20.1",
     "joi": "^8.0.5",
     "lodash": "^4.11.1",
     "orientjs": "^2.2.4",


### PR DESCRIPTION
**Changes**
**1. Remove dependency with package config.** 
Use internally the same configuration provided in the connection call.

```javascript
import * as rieluz from "rieluz";
rieluz.connect(process.env.ORIENTDB, (err) => {
  done(err);
});
```
In the current version you have to pass this config during the connection and also be accessible from `config.get('orientdb')` in order to declare the schemas. Which brings the next point:

**2. Lazy connection**
Vertex are inflated and only a connection is made after explicit call to `rieluz.connect` using the active connection.

**3. Insensitive case for Vertex.**
Find the vertex independently of minuscule/capital letter, but keep the original name.
